### PR TITLE
Add build workflow using vipm-io/action-vipm-build

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -1,0 +1,72 @@
+name: build (action)
+
+# Builds the VI Package using the reusable vipm-io/action-vipm-build action,
+# which encapsulates the container display/headless-LabVIEW plumbing and runs
+# refresh -> install -> build. Compare with the inline Build job in ci.yml.
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  Build:
+
+    runs-on: ubuntu-latest
+
+    # The LabVIEW container defaults to `sh`; use `bash` for predictable syntax.
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      LABVIEW_IMAGE: 2026q1patch2-linux
+
+    container:
+      image: nationalinstruments/labview:2026q1patch2-linux
+
+    steps:
+
+      - name: Install git for actions/checkout
+        # git is required by actions/checkout but is not in the base LabVIEW image.
+        run: apt-get update && apt-get install -y git
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Cache VIPM packages
+        uses: actions/cache@v5
+        env:
+          CACHE_VERSION: 1
+        with:
+          path: /usr/local/jki/vipm/cache/
+          key: vipm-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.LABVIEW_IMAGE }}-${{ hashFiles('source/.vipc', 'error.dragon') }}
+          restore-keys: |
+            vipm-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.LABVIEW_IMAGE }}-
+
+      - name: Refresh, install dependencies, and build the VI Package
+        id: build
+        # TODO: pin to @v1 once the action cuts a release.
+        uses: vipm-io/action-vipm-build@main
+        with:
+          path: source                 # auto-finds source/.vipb
+          refresh: 'true'
+          install: |
+            error.dragon
+          output_directory: dist
+          # LabVIEW version is auto-detected from the container (2026).
+          vipm_release_type: preview    # VIPM Linux builds ship on the preview channel
+          vipm_version: 26.3.0-3859
+          community_edition: 'true'
+          show_progress: 'true'
+          verbose: 'true'
+
+      - name: Upload Built Package as Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: vi-package-${{ env.LABVIEW_IMAGE }}
+          path: dist/*.vip

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -50,8 +50,9 @@ jobs:
 
       - name: Refresh, install dependencies, and build the VI Package
         id: build
-        # TODO: pin to @v1 once the action cuts a release.
-        uses: vipm-io/action-vipm-build@main
+        # Pinned to an exact version; no floating @v0/@v0.0 tags are published.
+        # For stronger supply-chain hardening, pin to the commit SHA instead.
+        uses: vipm-io/action-vipm-build@v0.0.0
         with:
           path: source                 # auto-finds source/.vipb
           refresh: 'true'

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -50,9 +50,9 @@ jobs:
 
       - name: Refresh, install dependencies, and build the VI Package
         id: build
-        # Pinned to an exact version; no floating @v0/@v0.0 tags are published.
-        # For stronger supply-chain hardening, pin to the commit SHA instead.
-        uses: vipm-io/action-vipm-build@v0.0.0
+        # Pinned to the head commit of vipm-io/action-vipm-build#1, which adds
+        # channel-aware "latest" resolution for the preview/develop channels.
+        uses: vipm-io/action-vipm-build@0b9ba53221c4d7434385c2d023acf9c82e5d2078
         with:
           path: source                 # auto-finds source/.vipb
           refresh: 'true'
@@ -61,9 +61,9 @@ jobs:
           output_directory: dist
           # LabVIEW version is auto-detected from the container (2026).
           vipm_release_type: preview    # VIPM Linux builds ship on the preview channel
-          # Exact preview build. The action cannot resolve a "latest preview" alias
-          # (it only special-cases `latest` on the stable channel), so pin explicitly.
-          vipm_version: 26.3.1-3977
+          # Track the latest preview build; resolves to the preview channel's
+          # latest_preview alias (requires action-vipm-build#1).
+          vipm_version: latest
           community_edition: 'true'
           show_progress: 'true'
           verbose: 'true'

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -53,9 +53,10 @@ jobs:
 
       - name: Refresh, install dependencies, and build the VI Package
         id: build
-        # Pinned to the head commit of vipm-io/action-vipm-build#1, which adds
-        # channel-aware "latest" resolution for the preview/develop channels.
-        uses: vipm-io/action-vipm-build@0b9ba53221c4d7434385c2d023acf9c82e5d2078
+        # Pinned to an exact version. v0.0.1 adds channel-aware "latest"
+        # resolution for the preview/develop channels (latest -> latest_preview).
+        # For stronger supply-chain hardening, pin to the commit SHA instead.
+        uses: vipm-io/action-vipm-build@v0.0.1
         with:
           path: source                 # auto-finds source/.vipb
           refresh: 'true'

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -61,7 +61,9 @@ jobs:
           output_directory: dist
           # LabVIEW version is auto-detected from the container (2026).
           vipm_release_type: preview    # VIPM Linux builds ship on the preview channel
-          vipm_version: 26.3.0-3859
+          # Exact preview build. The action cannot resolve a "latest preview" alias
+          # (it only special-cases `latest` on the stable channel), so pin explicitly.
+          vipm_version: 26.3.1-3977
           community_edition: 'true'
           show_progress: 'true'
           verbose: 'true'

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -25,6 +25,9 @@ jobs:
 
     env:
       LABVIEW_IMAGE: 2026q1patch2-linux
+      # vipm reads this from the environment; the default 60s liveliness window
+      # is too tight for this build (matches the value used in ci.yml).
+      VIPM_DESKTOP_LIVELINESS_TIMEOUT: 300
 
     container:
       image: nationalinstruments/labview:2026q1patch2-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
 
     env:
       LABVIEW_IMAGE: 2026q1patch2-linux
-      VIPM_RELEASE_TYPE: preview
-      VIPM_VERSION: 26.3.0-3859
+      VIPM_RELEASE_TYPE: release
+      VIPM_VERSION: 26.3.0-3963
       VIPM_COMMUNITY_EDITION: true
 
     steps:
@@ -86,8 +86,19 @@ jobs:
       - name: Install VIPM
         run: |
           apt-get update && apt-get install -y wget
-          wget -O /tmp/vipm.deb \
-            https://packages.jki.net/vipm/${VIPM_RELEASE_TYPE}/vipm_${VIPM_VERSION}_amd64.deb
+          case "${VIPM_RELEASE_TYPE}" in
+            preview)
+              VIPM_DEB_URL="https://packages.jki.net/vipm/preview/vipm_${VIPM_VERSION}_amd64.deb"
+              ;;
+            release)
+              VIPM_DEB_URL="https://traffic.libsyn.com/secure/jkinc/vipm_${VIPM_VERSION}_amd64.deb"
+              ;;
+            *)
+              echo "Unsupported VIPM_RELEASE_TYPE: ${VIPM_RELEASE_TYPE}" >&2
+              exit 1
+              ;;
+          esac
+          wget -O /tmp/vipm.deb "${VIPM_DEB_URL}"
           dpkg -i /tmp/vipm.deb && rm /tmp/vipm.deb
           vipm --version
 
@@ -124,9 +135,10 @@ jobs:
         with:
           path: /usr/local/jki/vipm/cache/
           # Key includes hashes of the project package manifests (.vipc and .dragon files)
-          key: vipm-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.LABVIEW_IMAGE }}-${{ env.VIPM_VERSION }}-${{ hashFiles('source/.vipc', 'error.dragon') }}
+          key: vipm-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.LABVIEW_IMAGE }}-${{ env.VIPM_RELEASE_TYPE }}-${{ env.VIPM_VERSION }}-${{ hashFiles('source/.vipc', 'error.dragon') }}
           restore-keys: |
-            vipm-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.LABVIEW_IMAGE }}-${{ env.VIPM_VERSION }}-
+            vipm-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.LABVIEW_IMAGE }}-${{ env.VIPM_RELEASE_TYPE }}-${{ env.VIPM_VERSION }}-
+            vipm-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.LABVIEW_IMAGE }}-${{ env.VIPM_RELEASE_TYPE }}-
             vipm-v${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ env.LABVIEW_IMAGE }}-
 
       - name: Print VIPM About

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
       VIPM_RELEASE_TYPE: release
       VIPM_VERSION: 26.3.0-3963
       VIPM_COMMUNITY_EDITION: true
+      VIPM_DESKTOP_LIVELINESS_TIMEOUT: 300
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,10 @@ jobs:
 
     env:
       LABVIEW_IMAGE: 2026q1patch2-linux
-      VIPM_RELEASE_TYPE: release
-      VIPM_VERSION: 26.3.0-3963
+      VIPM_RELEASE_TYPE: preview
+      VIPM_VERSION: latest_preview
+      # VIPM_RELEASE_TYPE: release
+      # VIPM_VERSION: 26.3.0-3963
       VIPM_COMMUNITY_EDITION: true
       VIPM_DESKTOP_LIVELINESS_TIMEOUT: 300
 


### PR DESCRIPTION
Adds a new workflow, `.github/workflows/build-action.yml`, that builds the VI Package via the reusable [`vipm-io/action-vipm-build`](https://github.com/vipm-io/action-vipm-build) action — replicating the important steps of the inline container `Build` job:

- `vipm refresh`
- `vipm install error.dragon`
- `vipm build source/.vipb`

The action encapsulates the LabVIEW-container plumbing (Xvfb display, `LVContainer.txt` marker, the `$HOME/natinst` copy, headless LabVIEW launch) and the VIPM install, so the workflow is just **checkout → cache → action → upload artifact**.

### Notes
- Pinned to `@main` for now; switch to `@v1` once the action cuts a release.
- VIPM is pinned to the `preview` channel build `26.3.0-3859` (VIPM Linux `.deb`s currently ship on `preview`).
- LabVIEW version is auto-detected from the container image (2026).
- `ci.yml` is left untouched, so the inline approach and the action-based approach can be compared side by side.